### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/TicTacToe.py
+++ b/TicTacToe.py
@@ -119,7 +119,7 @@ def getComputerMove(board, computerLetter):
 
     # Try to take one of the corners, if they are free.
     move = chooseRandomMoveFromList(board, [1, 3, 7, 9])
-    if move != None:
+    if move is not None:
         return move
 
     # Try to take the center, if it is free.


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tabuu9:Python-Games?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:tabuu9:Python-Games?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)